### PR TITLE
"Width and height of cutout needs to be defined."

### DIFF
--- a/src/Filter/Resize.php
+++ b/src/Filter/Resize.php
@@ -18,7 +18,7 @@ class Resize implements FilterInterface
             ]);
             $res = $smartcrop->analyse();
             $topCrop = $res['topCrop'];
-            $image->crop(min($topCrop['width'], $width), min($topCrop['height'], $height), $topCrop['x'], $topCrop['y']);
+            $image->crop(min($topCrop['width'], $width) ?: $width, min($topCrop['height'], $height) ?: $height, $topCrop['x'], $topCrop['y']);
         }
 
         if (isset($params['crop'])) {


### PR DESCRIPTION
Thanks for this plugin, it works well in general, but I just found one image for which SmartCrop doesn't work and throws this exception: Intervention\Image\Exception\InvalidArgumentException: Width and height of cutout needs to be defined.

When `$toCrop` is null, null is returned and image crop isn't happy with it. 
That's the case with a 200x200 smartcrop of a 498x1264 original image.