### PR TITLE
getFacadeAccessor now must return a container binding key

### DIFF
--- a/src/Facades/Thumbnail.php
+++ b/src/Facades/Thumbnail.php
@@ -13,6 +13,6 @@ class Thumbnail extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return static::$app[\Rolandstarke\Thumbnail\Thumbnail::class];
+        return \Rolandstarke\Thumbnail\Thumbnail::class;
     }
 }


### PR DESCRIPTION
Per the Laravel 9 [Upgrade Guide](https://laravel.com/docs/9.x/upgrade), getFacadeAccessor now must return a container binding key, rather than an object instance.